### PR TITLE
Function fixes

### DIFF
--- a/components/src/commonMain/kotlin/com/erdodif/capsulate/utility/CodeHighlight.kt
+++ b/components/src/commonMain/kotlin/com/erdodif/capsulate/utility/CodeHighlight.kt
@@ -18,6 +18,7 @@ import com.erdodif.capsulate.lang.program.grammar.expression.Comment
 import com.erdodif.capsulate.lang.program.grammar.expression.IntLit
 import com.erdodif.capsulate.lang.program.grammar.expression.KeyWord
 import com.erdodif.capsulate.lang.program.grammar.expression.LineEnd
+import com.erdodif.capsulate.lang.program.grammar.expression.NatLit
 import com.erdodif.capsulate.lang.program.grammar.expression.StrLit
 import com.erdodif.capsulate.lang.program.grammar.expression.Symbol
 import com.erdodif.capsulate.lang.program.grammar.expression.Token
@@ -103,6 +104,7 @@ class CodeHighlight private constructor(
             is Variable -> variable
             is KeyWord -> control
             is IntLit -> number
+            is NatLit -> number
             is StrLit -> string
             is ChrLit -> string
             is LineEnd -> parenthesis

--- a/language/src/commonMain/kotlin/com/erdodif/capsulate/lang/program/grammar/expression/Exp.kt
+++ b/language/src/commonMain/kotlin/com/erdodif/capsulate/lang/program/grammar/expression/Exp.kt
@@ -35,6 +35,7 @@ import com.erdodif.capsulate.lang.util.Right
 import com.erdodif.capsulate.lang.util._char
 import com.erdodif.capsulate.lang.util._integer
 import com.erdodif.capsulate.lang.util._keyword
+import com.erdodif.capsulate.lang.util._natural
 import com.erdodif.capsulate.lang.util._nonKeyword
 import com.erdodif.capsulate.lang.util.asString
 import com.erdodif.capsulate.lang.util.asum
@@ -192,6 +193,7 @@ val pStrLit: Parser<StrLit> = middle(
     many(orEither(right(char('\\'), anyChar), right(not(char('"')), anyChar))),
     _char('"')
 ) * { res, pos -> StrLit(res.asString(), pos) }
+val pNatLit: Parser<NatLit> = _natural * { lit, pos -> NatLit(lit, pos) }
 val pIntLit: Parser<IntLit> = _integer * { lit, pos -> IntLit(lit, pos) }
 val pBoolLit: Parser<BoolLit> =
     or(_keyword("true"), _keyword("false")) * { lit, pos -> BoolLit(lit is Left<*>, pos) }
@@ -224,9 +226,8 @@ val pArrayLit: Parser<ArrayLit<Value>> = {
     }]()
 }
 
-//val pIndex: Parser<Index> = or()
-
 val litOrder: Array<Parser<Exp<*>>> = arrayOf(
+    //pNatLit, temporarily
     pIntLit,
     pBoolLit,
     pChrLit,

--- a/language/src/commonMain/kotlin/com/erdodif/capsulate/lang/program/grammar/expression/operator/BuiltInOperators.kt
+++ b/language/src/commonMain/kotlin/com/erdodif/capsulate/lang/program/grammar/expression/operator/BuiltInOperators.kt
@@ -191,7 +191,7 @@ data object Or : BinaryOperator<VBool, VBool>(
 }
 
 @KParcelize
-data object Sign : UnaryOperator<VNum<*>, VWhole>(
+data object Sign : UnaryOperator<VWhole, VNum<BigInteger>>(
     20,
     "-",
     _char('-'),

--- a/language/src/commonMain/kotlin/com/erdodif/capsulate/lang/program/grammar/function/Function.kt
+++ b/language/src/commonMain/kotlin/com/erdodif/capsulate/lang/program/grammar/function/Function.kt
@@ -97,7 +97,7 @@ data class FunctionCall<T : Value>(
     override fun evaluate(context: Environment): Right<PendingExpression<Value, T>> = Right(
         PendingExpression(
             this as FunctionCall<Value>,
-            context.functions[name]!! as Function<Value>
+            context.functions[name]!!
         ) { Left(it as T) })
 
     override fun toString(state: ParserState, parentStrength: Int) =
@@ -123,7 +123,7 @@ val sFunction: Parser<Function<Value>> = {
         ).also {
             it.position = state.position
         }
-        val blocks = tmpEnv.withReturn(
+        val blocks = tmpEnv.withFunctionScope(
             label, delimit(
                 orEither(
                     middle(
@@ -172,7 +172,7 @@ data class Return<out T : Value> @OptIn(ExperimentalUuidApi::class) constructor(
 }
 
 val sReturn: Parser<Statement> = right(_keyword("return"), pExp)[{ (value, state, pos) ->
-    if (allowReturn && currentFunctionLabel != null) {
+    if (inFunctionScope && currentFunctionLabel != null) {
         if (assumptions[currentFunctionLabel!!] != null) {
             if (assumptions[currentFunctionLabel!!] != value.getType(assumptions)) {
                 raiseError(

--- a/language/src/commonMain/kotlin/com/erdodif/capsulate/lang/program/grammar/function/Method.kt
+++ b/language/src/commonMain/kotlin/com/erdodif/capsulate/lang/program/grammar/function/Method.kt
@@ -83,11 +83,15 @@ val sMethod: Parser<Method> =
     }
 
 val sMethodCall: Parser<Statement> = delimit(sKnownPattern)[{
-    val (pattern, params) = it.value
-    val method = methods.firstOrNull { it.pattern == pattern }
-    if (method == null) {
-        fail("Can't find any method with the given pattern '$pattern'")
+    if (inFunctionScope) {
+        fail("Cannot use call for a method in a function!")
     } else {
-        pass(it.match.start, MethodCall(method, params, it.match))
+        val (pattern, params) = it.value
+        val method = methods.firstOrNull { it.pattern == pattern }
+        if (method == null) {
+            fail("Can't find any method with the given pattern '$pattern'")
+        } else {
+            pass(it.match.start, MethodCall(method, params, it.match))
+        }
     }
 }]

--- a/language/src/commonMain/kotlin/com/erdodif/capsulate/lang/util/Parser.kt
+++ b/language/src/commonMain/kotlin/com/erdodif/capsulate/lang/util/Parser.kt
@@ -15,8 +15,6 @@ open class ParserState(
     methods: List<Method> = listOf(),
     assumptions: List<Pair<String, Type>> = listOf()
 ) {
-    var allowReturn: Boolean = false
-        protected set
 
     val functions: MutableList<Function<Value>> = functions.toMutableList()
     val methods: MutableList<Method> = methods.toMutableList()
@@ -25,6 +23,8 @@ open class ParserState(
     val line: Int
         get() = input.substring(0, position).count { it == '\n' } + 1
     var currentFunctionLabel: String? = null
+    val inFunctionScope: Boolean
+        get() = currentFunctionLabel != null
 
     var position: Int = 0
 
@@ -71,12 +71,10 @@ open class ParserState(
         }
     }
 
-    internal inline fun <T> withReturn(label:String,crossinline parser: Parser<T>): ParserResult<T> {
-        allowReturn = true
+    internal inline fun <T> withFunctionScope(label:String, crossinline parser: Parser<T>): ParserResult<T> {
         currentFunctionLabel = label
         val result = parser()
         currentFunctionLabel = null
-        allowReturn = false
         return result
     }
 


### PR DESCRIPTION
# Function scope fix

> Non-determinism in functions is strictly prohibited, the parser must act accordingly

Within a function scope:

- Disallow atomic, await and parallel statements
- Disallow Method call